### PR TITLE
Update for multiple tracked directories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,12 @@
 # Introduction
-Performs a hourly scan and scan on boot for any conflict files in a single syncthing shared directory.
+Performs a hourly scan and scan on boot for any conflict files in multiple syncthing shared directories.
 Sends a desktop push notification when a conflict has been found.
 
 ## Manual installation instructions
+Ensure `notify-send` is installed with `notify-send -v` and install it if necessary (e.g. `sudo apt install libnotify-bin`).
 Place the timer and service units in `~/.config/systemd/user/` and create that directory if needed\
-Edit script and provide root directory of the syncthing folder that needs to be tracked\
-For example: `SYNCTHING_DIR=~/my-syncthing-default-folder`\
+Edit script and provide root directories of syncthing folders that need to be tracked\
+For example: `SYNCTHING_DIRS=("~/my-syncthing-default-folder" "~/my-syncthing-special-folder")`\
 Ensure that script has executable rights (chmod +x)\
 Place the shell script in /usr/local/bin/\
 Reload systemd with systemctl daemon-reload\

--- a/syncthing-conflict-notifier
+++ b/syncthing-conflict-notifier
@@ -1,8 +1,10 @@
 #!/bin/bash
-# Edit variable value with root location of a syncthing folder that needs to be watched
-SYNCTHING_DIR=
+# Edit variable value with root locations of syncthing folders that needs to be watched
+SYNCTHING_DIRS=("%path1%" "%path2%")
 
-if [[ -n `ls -1 "$SYNCTHING_DIR"/*.sync-conflict-* 2> /dev/null` ]]
-then
-	notify-send --urgency=critical "NEW SYNCTHING CONFLICTS DETECTED!!" > /dev/null
-fi
+for FOLDER in ${SYNCTHING_DIRS[@]}; do
+	if [[ -n `ls -1 "$FOLDER"/*.sync-conflict-* 2> /dev/null` ]]
+	then
+		notify-send -u critical -a syncthing-conflict-notifier "NEW SYNCTHING CONFLICTS IN ${FOLDER} DETECTED!!" > /dev/null
+	fi
+done


### PR DESCRIPTION
By wrapping the file check in a for loop, this can now check multiple directories for conflict files.
The comments have also been adjusted to reflect that